### PR TITLE
fixed #328 and #316 adding width and scrollbar width margin to the container

### DIFF
--- a/thirdparty/ng-scrollbar/dist/ng-customscrollbar.js
+++ b/thirdparty/ng-scrollbar/dist/ng-customscrollbar.js
@@ -52,7 +52,8 @@ angular.module('ngCustomScrollbar', []).directive('ngCustomScrollbar', [
           pageStyle = {
             position: 'relative',
             top: page.top + 'px',
-            overflow: 'hidden'
+            overflow: 'hidden',
+            width: 'calc(100% - 16px)'
           };
         };
         var redraw = function () {

--- a/thirdparty/ng-scrollbar/dist/ng-scrollbar.js
+++ b/thirdparty/ng-scrollbar/dist/ng-scrollbar.js
@@ -48,7 +48,8 @@ angular.module('ngScrollbar', []).directive('ngScrollbar', [
           pageStyle = {
             position: 'relative',
             top: page.top + 'px',
-            overflow: 'hidden'
+            overflow: 'hidden',
+            width: 'calc(100% - 16px)'
           };
         };
         var redraw = function () {


### PR DESCRIPTION
Fix for #328 and consequently #316 

Current thirdparty scrolling plugin uses absolute positioning and overflow hidden to display the content. Since the container needed to have width of `(parent_width - vertical_scrollbar_width)`, I added `width: calc(100% - 16px)` in the thirdparty css style template. 